### PR TITLE
Product Note: make warning less scary

### DIFF
--- a/src/lib/product_note/product_note.js
+++ b/src/lib/product_note/product_note.js
@@ -58,7 +58,7 @@ class ProductNote extends Component {
       const values = {
          note           : [color.blueLight4, color.blueLight3, color.blueDark1, color.blueLight1, "check"],
          disclaimer : [color.yellowLight4, color.yellowLight3, color.yellowDark1, color.yellowLight1, "alert-circle"],
-         warning     : [color.redLight4, color.redLight3, color.redDark1, color.redLight1, "x"]
+         warning     : [color.yellowLight4, color.yellowLight3, color.yellowDark1, color.yellowLight1, "alert-triangle"]
       };
 
       const fill = values[type][0];


### PR DESCRIPTION
We don't want the warnings on product pages to scare people away from
buying the product.

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/806152/65647346-45851380-dfb3-11e9-8812-b14817037728.png) | ![image](https://user-images.githubusercontent.com/806152/65647350-47e76d80-dfb3-11e9-8d6b-0bd932c217d6.png) | 

Connects https://github.com/iFixit/ifixit/issues/30223