### PR TITLE
Dependencies: bump to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1516,9 +1516,9 @@
       }
     },
     "@core-ds/primitives": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@core-ds/primitives/-/primitives-0.12.1.tgz",
-      "integrity": "sha512-/cqbRTljI3dRYfmAiRjk6dvvd4TVQ8/CA6bfC9cMC9zZ3wE1DJYabyl/h9qkHIKyQGwFt2MryDf3RPwZ3sskKw=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@core-ds/primitives/-/primitives-1.0.0.tgz",
+      "integrity": "sha512-KzpcY01qe4JNW0viyH4fPtcXr8+Yzjxfe7L6pgBN2HNDr9EN4dGVmWSteRhgsHyYDxac/KVyXAxeTWUv1ABsnw=="
     },
     "@csstools/convert-colors": {
       "version": "1.4.0",
@@ -1590,14 +1590,14 @@
       }
     },
     "@ifixit/localize": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@ifixit/localize/-/localize-0.1.0.tgz",
-      "integrity": "sha512-mWnIHBoW9y0CIu00kspXX0MLAdN9EognuaqVCGG865PMoPxyW4ngmR/DonlvhsAAkf7dE/uh7RMx3Jk5uBwz3Q=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ifixit/localize/-/localize-1.0.0.tgz",
+      "integrity": "sha512-XleJqL6UCVshzy8v/MH5vRHSixGv3z2SkQunsAozfW5U2fMTbQ8xoZXOfrjAakhfiPOmJxFDBI/VDnC6L7B1Tg=="
     },
     "@ifixit/toolbox": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@ifixit/toolbox/-/toolbox-0.13.0.tgz",
-      "integrity": "sha512-6gOp1vp4rWYvmifjCnYmYc4omcZk185jTkRJppnC/+a/3B6ixQDrarUAHNNF5t1UrrLE3eFnmOpyCT6s527QvQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ifixit/toolbox/-/toolbox-1.1.0.tgz",
+      "integrity": "sha512-vgHKy/VicDN7CstGHpC8fIbguXeGfW4f4x/pEvEFxtXz0O2HmzltWL/GPoX9eHYYjkMhU8JSGqPC0y9TQUDhaA==",
       "requires": {
         "feather-icons": "github:iFixit/feather#7921f659b662e8b6d19b35598e97dd01e6f4745f",
         "glamor": "^2.20.40",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "dist"
   ],
   "dependencies": {
-    "@core-ds/primitives": "^0.12.1",
-    "@ifixit/localize": "^0.1.0",
-    "@ifixit/toolbox": "^0.13.0",
+    "@core-ds/primitives": "^1.0.0",
+    "@ifixit/localize": "^1.0.0",
+    "@ifixit/toolbox": "^1.1.0",
     "styled-components": "^4.3.1"
   },
   "scripts": {


### PR DESCRIPTION
We recently put out new versions of each of these deps.

* Toolbox: switch from rems to px
* Primitives: switch from rems to px
* Localize: just a bump to get us to 1.0