### PR TITLE
Core-icons: bump to v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1516,9 +1516,9 @@
       }
     },
     "@core-ds/icons": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@core-ds/icons/-/icons-0.7.0.tgz",
-      "integrity": "sha512-zuQIebRLiL7Ng3TaD3GczyWGS7FbI7CBpcGYZDMF8QA2WY/2Hm4bqdwU+vkXetEu1nt+i4Tsgm2kpYC8BwD5dQ=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@core-ds/icons/-/icons-1.0.0.tgz",
+      "integrity": "sha512-UXV43brYaU+yo4/imEAfMObXGPSl+J0QtBThpu8GG3qoBynBTwD0BMzuzydz6tSKxdLLnq4v6PnTzlEFgAKpwA=="
     },
     "@core-ds/primitives": {
       "version": "1.0.0",
@@ -1604,20 +1604,12 @@
       "resolved": "https://registry.npmjs.org/@ifixit/toolbox/-/toolbox-1.1.0.tgz",
       "integrity": "sha512-vgHKy/VicDN7CstGHpC8fIbguXeGfW4f4x/pEvEFxtXz0O2HmzltWL/GPoX9eHYYjkMhU8JSGqPC0y9TQUDhaA==",
       "requires": {
+        "feather-icons": "github:iFixit/feather#7921f659b662e8b6d19b35598e97dd01e6f4745f",
         "glamor": "^2.20.40",
         "glamorous": "^4.13.1",
         "prop-types": "^15.6.1",
         "react-star-ratings": "^2.3.0",
         "styled-components": "^4.0.0"
-      },
-      "dependencies": {
-        "feather-icons": {
-          "version": "github:iFixit/feather#7921f659b662e8b6d19b35598e97dd01e6f4745f",
-          "from": "github:iFixit/feather#7921f659b662e8b6d19b35598e97dd01e6f4745f",
-          "requires": {
-            "classnames": "^2.2.5"
-          }
-        }
       }
     },
     "@jest/console": {
@@ -6973,6 +6965,13 @@
             "asap": "~2.0.3"
           }
         }
+      }
+    },
+    "feather-icons": {
+      "version": "github:iFixit/feather#7921f659b662e8b6d19b35598e97dd01e6f4745f",
+      "from": "github:iFixit/feather",
+      "requires": {
+        "classnames": "^2.2.5"
       }
     },
     "figgy-pudding": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dist"
   ],
   "dependencies": {
-    "@core-ds/icons": "^0.7.0",
+    "@core-ds/icons": "^1.0.0",
     "@core-ds/primitives": "^1.0.0",
     "@ifixit/localize": "^1.0.0",
     "@ifixit/toolbox": "^1.1.0"


### PR DESCRIPTION
No functional changes, just bumping cause the libnrary's been stable for
a long time and there's no point to be 0.x anymore.