### PR TITLE
Product Reviews: stop sorting them

### DIFF
--- a/src/lib/product_reviews/product_reviews.js
+++ b/src/lib/product_reviews/product_reviews.js
@@ -64,17 +64,8 @@ class ProductReviews extends Component {
       });
    };
 
-   // Sort reviews by date created.
-   get sortedReviews() {
-      const { reviews } = this.props.productReviews;
-
-      return reviews.sort((a, b) => {
-         return b.created_date - a.created_date;
-      });
-   }
-
    get reviewsWithText() {
-      const reviews = this.sortedReviews;
+      const { reviews } = this.props.productReviews;
 
       return reviews.filter(review => review.body || review.headline);
    }


### PR DESCRIPTION
The reviews passed into the component have already been sorted,
and trying to keep two different sorting mechanisms in sync
doesn't make sense.