### PR TITLE
ProductReviews: Conditionally hide link to write/edit a review

### DIFF
--- a/src/lib/product_reviews/product_reviews.js
+++ b/src/lib/product_reviews/product_reviews.js
@@ -72,6 +72,7 @@ class ProductReviews extends Component {
 
    render() {
       const { itemcode, productReviews, reviewsLink } = this.props;
+      const reviewsUrl = (reviewsLink && itemcode) && `${reviewsLink}/${itemcode}`;
       const { itemLimit } = this.state;
       const reviewsWithText = this.reviewsWithText;
       const noReviews = reviewsWithText.length === 0;
@@ -80,8 +81,7 @@ class ProductReviews extends Component {
          <Container id="productReviews">
             <Visualizer
                productReviews={productReviews}
-               itemcode={itemcode}
-               reviewsLink={reviewsLink}
+               reviewsUrl={reviewsUrl}
             />
             <ReviewsContainer noReviews={noReviews}>
                {noReviews && (
@@ -94,13 +94,12 @@ class ProductReviews extends Component {
                      return (
                         <Review
                            key={`${review.author.name}-${index}`}
-                           itemcode={itemcode}
                            review={review}
                            showBorder={
                               reviewsWithText.length > 1 &&
                               index < reviewsWithText.length - 1
                            }
-                           reviewsLink={reviewsLink}
+                           reviewsUrl={reviewsUrl}
                         />
                      );
                   }

--- a/src/lib/product_reviews/review/author.js
+++ b/src/lib/product_reviews/review/author.js
@@ -20,7 +20,7 @@ const Name = styled.h3`
    line-height: 24px;
 `;
 
-const Author = ({ author, itemcode, reviewsLink }) => {
+const Author = ({ author, reviewsUrl }) => {
    const { name, avatar, url, userid, canEdit } = author;
 
    return (
@@ -29,8 +29,8 @@ const Author = ({ author, itemcode, reviewsLink }) => {
             <Avatar src={avatar} size={28} />
             <Name itemProp="author">{name}</Name>
          </Link>
-         {canEdit && reviewsLink && (
-            <a href={`${reviewsLink}/${itemcode}?userid=${userid}`}>
+         {canEdit && reviewsUrl && (
+            <a href={`${reviewsUrl}?userid=${userid}`}>
                <Button size="small">{_js('Edit')}</Button>
             </a>
          )}
@@ -40,8 +40,7 @@ const Author = ({ author, itemcode, reviewsLink }) => {
 
 Author.propTypes = {
    author: PropTypes.object.isRequired,
-   itemcode: PropTypes.string,
-   reviewsLink: PropTypes.string,
+   reviewsUrl: PropTypes.string,
 };
 
 export default Author;

--- a/src/lib/product_reviews/review/index.js
+++ b/src/lib/product_reviews/review/index.js
@@ -18,7 +18,7 @@ const Container = styled.div`
    }
 `;
 
-const Review = ({ itemcode, review, showBorder, locale, reviewsLink }) => {
+const Review = ({ review, showBorder, locale, reviewsUrl }) => {
    const { rating, headline, body, body_trunc, author, created_date } = review;
    const date = new Date(created_date * 1000).toLocaleDateString(locale, {
       year: 'numeric',
@@ -32,7 +32,7 @@ const Review = ({ itemcode, review, showBorder, locale, reviewsLink }) => {
          itemScope
          itemType="http://schema.org/Review"
          showBorder={showBorder}>
-         <Author author={author} itemcode={itemcode} reviewsLink={reviewsLink} />
+         <Author author={author} reviewsUrl={reviewsUrl} />
          <Header rating={rating} headline={headline} date={date} />
          <ReviewBody body={body} body_trunc={body_trunc} />
       </Container>

--- a/src/lib/product_reviews/visualizer/index.js
+++ b/src/lib/product_reviews/visualizer/index.js
@@ -58,7 +58,7 @@ const ReviewCount = styled.h3`
 
 class Visualizer extends Component {
    render() {
-      const { productReviews, itemcode, reviewsLink } = this.props;
+      const { productReviews, reviewsUrl } = this.props;
       const { average, groupedReviews } = productReviews;
       const numReviews = productReviews.count;
 
@@ -102,9 +102,7 @@ class Visualizer extends Component {
                ))
                .reverse()}
 
-            {reviewsLink && (
-               <ReviewLink itemcode={itemcode} reviewsLink={reviewsLink} />
-            )}
+            {reviewsUrl && <ReviewLink reviewsUrl={reviewsUrl} />}
          </Container>
       );
    }
@@ -112,8 +110,7 @@ class Visualizer extends Component {
 
 Visualizer.propTypes = {
    productReviews: PropTypes.object.isRequired,
-   itemcode: PropTypes.string,
-   reviewsLink: PropTypes.string,
+   reviewsUrl: PropTypes.string,
 };
 
 export default Visualizer;

--- a/src/lib/product_reviews/visualizer/review_link.js
+++ b/src/lib/product_reviews/visualizer/review_link.js
@@ -9,12 +9,10 @@ const Container = styled.div`
    margin-top: ${spacing[4]};
 `;
 
-const ReviewLink = ({ itemcode, reviewsLink }) => {
-   const url = `${reviewsLink}/${itemcode}`;
-
+const ReviewLink = ({ reviewsUrl }) => {
    return (
       <Container>
-         <Button href={url} fullWidth design="primary">{_js('Write a product review')}</Button>
+         <Button href={reviewsUrl} fullWidth design="primary">{_js('Write a product review')}</Button>
       </Container>
    );
 };


### PR DESCRIPTION
Summary
---
Let's allow users of this repo (e.g Shopify) to conditionally show "Write a review," as Shopify doesn't support writing reviews yet.

Method
---
- Added propTypes to ProductReviews and its children
- For children of ProductReviews, Combined `itemcode` and `reviewsLink` into one prop: `reviewsUrl`, as that is their only purpose.
- Conditionally show the "Write a review" link and the "Edit a review" link if one of `itemcode` and `reviewsLink` is not passed to `ProductReviews`:

| Product Review Links present | Product Review Links hidden |
| ----------------------------- | ------------------------------ |
| ![Screen Shot 2019-12-04 at 11 52 45 AM](https://user-images.githubusercontent.com/17971850/70178183-ab1b0d80-1690-11ea-96c7-8b62196d4b9d.png) | ![Screen Shot 2019-12-04 at 11 52 55 AM](https://user-images.githubusercontent.com/17971850/70178190-aeae9480-1690-11ea-8b8f-7fc8d0aa23e8.png) |

CC: @sterlinghirsh @danielbeardsley 

Closes iFixit/ifixit#30939