### PR TITLE
Product Reviews: improve author schema data

### DIFF
--- a/src/lib/product_reviews/review/author.js
+++ b/src/lib/product_reviews/review/author.js
@@ -28,7 +28,7 @@ const Author = ({ author, reviewsUrl }) => {
          <Link href={url}>
             <Avatar src={avatar} size={28} />
             <div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
-               <Name itemProp="name">{name}</Name>
+               <Name itemprop="name">{name}</Name>
             </div>
          </Link>
          {canEdit && reviewsUrl && (


### PR DESCRIPTION
By default the author's @type was a "Thing". A "Person" is a better
description.

Connects https://github.com/iFixit/ifixit/issues/31725