### PR TITLE
Use standard React attributes for microdata

### DIFF
--- a/src/lib/product_reviews/review/author.js
+++ b/src/lib/product_reviews/review/author.js
@@ -27,7 +27,7 @@ const Author = ({ author, reviewsUrl }) => {
       <Container>
          <Link href={url}>
             <Avatar src={avatar} size={28} />
-            <div itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+            <div itemProp="author" itemScope="" itemType="https://schema.org/Person">
                <Name itemprop="name">{name}</Name>
             </div>
          </Link>


### PR DESCRIPTION
We were using lower-case versions of the attributes, which [may or may
not be rendered](https://reactjs.org/blog/2017/09/08/dom-attributes-in-react-16.html), depending on the version of React. They seem to be
causing React warnings (as expected, according to the docs), which are
being rendered as console errors, thus failing our tests when they
appear.

Connects ifixit/ifixit#32070