### PR TITLE
API: Adjust url

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,4 +1,4 @@
-const baseUrl = 'https://ifixit.com/api/2.0/';
+const baseUrl = 'https://www.ifixit.com/api/2.0/';
 
 export async function post(endpoint, data = {}) {
    const response = await fetch(baseUrl + endpoint, {


### PR DESCRIPTION
Although this worked, it was causing a 301 to `www`. We might as well be direct.

CC @sterlinghirsh 

qa_req 0