### PR TITLE
Notify product: Adjust error handling

### DIFF
--- a/src/lib/notify_product/notify_product.js
+++ b/src/lib/notify_product/notify_product.js
@@ -101,22 +101,30 @@ const NotifyProduct = ({ email, sku, salesChannelID }) => {
          sales_channelid: salesChannelID,
       })
          .then(response => {
-            setStage(notifyStage.CONFIRMATION);
-            if (!response.ok) {
-               response.json().then(responseBody => {
+            if (response.ok) {
+               return;
+            }
+
+            // Determine what message we want to send
+            if (response.status >= 400 && response.status < 500) {
+               return response.json().then(responseBody => {
                   setConfirmationStatus({
                      type: StatusType.ERROR,
                      message: responseBody.message,
                   });
                });
+            } else {
+               throw new Error('Server error');
             }
          })
-         .catch(err => {
-            setStage(notifyStage.CONFIRMATION);
+         .catch(() => {
             setConfirmationStatus({
                type: StatusType.ERROR,
-               message: err.message,
+               message: _js('Request failed'),
             });
+         })
+         .then(() => {
+            setStage(notifyStage.CONFIRMATION);
          });
    };
 


### PR DESCRIPTION
If the API returned a 500 we were failing because the response wasn't sent as JSON. On 500s, we probably want to show our own message anyways.

## QA
A good way to test this might be to hard code the `cart/product/notifyWhenInStock` endpoint to return a 400 validation error or a 500 error as well as leave it unmodified. The component should work and display an appropriate message in each case.

CC @sterlinghirsh @danielbeardsley

Connects https://github.com/iFixit/ifixit/issues/34638