### PR TITLE
Notify Product: Fix minor UI bugs

### DIFF
--- a/src/lib/notify_product/notify_product.js
+++ b/src/lib/notify_product/notify_product.js
@@ -14,7 +14,7 @@ import { post } from '../api';
  */
 const NotifyContainer = styled.div`
    position: relative;
-   height: 60px;
+   height: 63px;
    overflow: hidden;
 `;
 


### PR DESCRIPTION
This pull does two things:
1. Passes `className` through so that we can style `NotifyProduct`.
2. Makes the container slightly bigger to avoid cutting off the confirmation.

qa_req 0

Connects https://github.com/iFixit/ifixit/issues/34638