### PR TITLE
Out of stock: set font size

### DIFF
--- a/src/lib/notify_product/notify_product.js
+++ b/src/lib/notify_product/notify_product.js
@@ -2,7 +2,7 @@ import React, { useState, useRef } from 'react';
 import styled from 'styled-components';
 import { _js } from '@ifixit/localize';
 import { Button, TextField } from '@ifixit/toolbox';
-import { color } from '@core-ds/primitives';
+import { color, fontSize } from '@core-ds/primitives';
 import Status, { StatusType } from './status';
 import { post } from '../api';
 
@@ -34,6 +34,7 @@ const OutOfStock = styled.span`
    display: flex;
    align-items: center;
    color: ${color.red};
+   font-size: ${fontSize[1]};
 `;
 
 const EmailForm = styled.form`


### PR DESCRIPTION
We weren't setting a font size on here before, so the text ended up being very small on iFixit due to a global style. The old notify was 13px, but I'd rather use a core value (14px).

This is how it should look in the context of an iFixit product page:
![image](https://user-images.githubusercontent.com/51836911/95930765-33bc0d00-0d7c-11eb-9e15-015bb21fb0c0.png)

## QA
We're already going to get this QAd for this pull: https://github.com/iFixit/ifixit/pull/34689, so I don't see a point in doing it twice.
qa_req 0

Connects https://github.com/iFixit/ifixit/issues/34638