### PR TITLE
Reviews: Truncate body on frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifixit/product-page-components",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ifixit/product-page-components",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "files": [

--- a/src/example/example_reviews.json
+++ b/src/example/example_reviews.json
@@ -151,8 +151,7 @@
         "avatar": "https://www.cominor.com/igi/WjVyykdlOWEImZYd.thumbnail",
         "url": "/User/1610487/Colin+Wood",
         "canEdit": false
-      },
-      "body_trunc": "Handy-dandy."
+      }
     },
     {
       "reviewid": 2927,
@@ -169,8 +168,7 @@
         "avatar": "https://www.cominor.com/static/images/avatars/User/ifixit/avatar-7.thumbnail",
         "url": "/User/3072205/Richard+Hanewald",
         "canEdit": false
-      },
-      "body_trunc": "Worked well!"
+      }
     },
     {
       "reviewid": 2913,
@@ -221,8 +219,7 @@
         "avatar": "https://www.cominor.com/static/images/avatars/User/ifixit/avatar-4.thumbnail",
         "url": "/User/1231875/djddirty",
         "canEdit": false
-      },
-      "body_trunc": "Great tool"
+      }
     },
     {
       "reviewid": 2842,
@@ -239,8 +236,7 @@
         "avatar": "https://www.cominor.com/static/images/avatars/User/ifixit/avatar-7.thumbnail",
         "url": "/User/49890/hewsey",
         "canEdit": false
-      },
-      "body_trunc": "Part of the mandatory kit."
+      }
     },
     {
       "reviewid": 2731,
@@ -257,8 +253,7 @@
         "avatar": "https://www.cominor.com/static/images/avatars/User/ifixit/avatar-4.thumbnail",
         "url": "/User/2972283/Miguel+Vazquez",
         "canEdit": false
-      },
-      "body_trunc": "Perfect for disassembly jobs"
+      }
     },
     {
       "reviewid": 2625,
@@ -275,8 +270,7 @@
         "avatar": "https://www.cominor.com/static/images/avatars/User/ifixit/avatar-10.thumbnail",
         "url": "/User/3103621/Rhonda+Lester",
         "canEdit": false
-      },
-      "body_trunc": "Thank you IFIXIT.  If not for this tool, I would have NEVER been able to successfully open my metal case iPod 7th Generation Classic. I actually tried to get a local repair place who advertises that they put batteries in iPods to put it in. They said the metal case iPods are the only ones they WILL "
+      }
     },
     {
       "reviewid": 2616,
@@ -327,8 +321,7 @@
         "avatar": "https://www.cominor.com/static/images/avatars/User/ifixit/avatar-2.thumbnail",
         "url": "/User/1703675/Ed+Fiala",
         "canEdit": false
-      },
-      "body_trunc": "I've had great going with the regular spudgers; though I've yet to give them a go, they feel to be an improvement."
+      }
     },
     {
       "reviewid": 2568,
@@ -345,8 +338,7 @@
         "avatar": "https://www.cominor.com/igi/4tcfvDZNHWLTeahB.thumbnail",
         "url": "/User/1349754/KC+Bills",
         "canEdit": false
-      },
-      "body_trunc": "We were hoping for so much more with these. We were very excited when we found out about these. The edge of these aren't as sharp as the standard spuders. We bought 3 of them and 2 of them lost their edge on first use. We currently get plastic spuders for about 25 cents each, these are roughly 12 ti"
+      }
     },
     {
       "reviewid": 2564,
@@ -363,8 +355,7 @@
         "avatar": "https://www.cominor.com/static/images/avatars/User/ifixit/avatar-2.thumbnail",
         "url": "/User/1009422/RDB",
         "canEdit": false
-      },
-      "body_trunc": "I bought this tool based on the description of its advantages  because I've got a project coming up.  Delivery was prompt and the tool shows promise for my use."
+      }
     },
     {
       "reviewid": 2554,
@@ -381,8 +372,7 @@
         "avatar": "https://www.cominor.com/igi/A1GG3jmdBHmcaaij.thumbnail",
         "url": "/User/1389565/Ralph+Malone",
         "canEdit": false
-      },
-      "body_trunc": "what can you say about a spludger fast shipping?"
+      }
     },
     {
       "reviewid": 2553,
@@ -399,8 +389,7 @@
         "avatar": "https://www.cominor.com/igi/A1GG3jmdBHmcaaij.thumbnail",
         "url": "/User/1389565/Ralph+Malone",
         "canEdit": false
-      },
-      "body_trunc": "what can you say about a spludger fast shipping?"
+      }
     },
     {
       "reviewid": 2552,
@@ -417,8 +406,7 @@
         "avatar": "https://www.cominor.com/static/images/avatars/User/ifixit/avatar-7.thumbnail",
         "url": "/User/2474523/Jane+Nearing",
         "canEdit": false
-      },
-      "body_trunc": "Got 2.  One joins other tiny tools in my purse.  I'm known as the go-to for tools.  It's the Girl Scout training."
+      }
     },
     {
       "reviewid": 2493,
@@ -435,8 +423,7 @@
         "avatar": "https://www.cominor.com/static/images/avatars/User/ifixit/avatar-2.thumbnail",
         "url": "/User/3077913/Mark+Blockinger",
         "canEdit": false
-      },
-      "body_trunc": "I used it to pry up parts, scrap old thermal paste off CPU and GPU."
+      }
     },
     {
       "reviewid": 2488,
@@ -538,8 +525,7 @@
         "avatar": "https://www.cominor.com/static/images/avatars/User/ifixit/avatar-6.thumbnail",
         "url": "/User/3064144/eddyriachy",
         "canEdit": false
-      },
-      "body_trunc": "Great"
+      }
     },
     {
       "reviewid": 2375,
@@ -556,8 +542,7 @@
         "avatar": "https://www.cominor.com/static/images/avatars/User/ifixit/avatar-8.thumbnail",
         "url": "/User/3086216/Drew+Hickok",
         "canEdit": false
-      },
-      "body_trunc": "It spudges in a unique and special way..."
+      }
     },
     {
       "reviewid": 2326,
@@ -591,8 +576,7 @@
         "avatar": "https://www.cominor.com/static/images/avatars/User/ifixit/avatar-4.thumbnail",
         "url": "/User/2972440/Alicia+Witherill",
         "canEdit": false
-      },
-      "body_trunc": "This tool worked exactly as needed for replacing my hard drive in my iMac."
+      }
     },
     {
       "reviewid": 2238,
@@ -660,8 +644,7 @@
         "avatar": "https://www.cominor.com/igi/5JbcdVJVsE5SUUHQ.thumbnail",
         "url": "/User/3067274/Joe+Montgomery",
         "canEdit": false
-      },
-      "body_trunc": "Just a very useful tool."
+      }
     },
     {
       "reviewid": 2095,
@@ -678,8 +661,7 @@
         "avatar": "https://www.cominor.com/static/images/avatars/User/ifixit/avatar-7.thumbnail",
         "url": "/User/1316157/Hector+Perez",
         "canEdit": false
-      },
-      "body_trunc": "Spare just in case the others break. Excellent quality."
+      }
     },
     {
       "reviewid": 2058,
@@ -696,8 +678,7 @@
         "avatar": "https://www.cominor.com/static/images/avatars/User/ifixit/avatar-12.thumbnail",
         "url": "/User/2202776/Ron+Stafford",
         "canEdit": false
-      },
-      "body_trunc": "Perfect tool for MacBook Pro fan connectors"
+      }
     },
     {
       "reviewid": 1841,
@@ -714,8 +695,7 @@
         "avatar": "https://www.cominor.com/igi/T2HsL1DPbiunJIZj.thumbnail",
         "url": "/User/2159450/Andr%C3%A9s+Lloret",
         "canEdit": false
-      },
-      "body_trunc": "Great tool! works perfectly!"
+      }
     },
     {
       "reviewid": 1776,
@@ -783,8 +763,7 @@
         "avatar": "https://www.cominor.com/static/images/avatars/User/ifixit/avatar-12.thumbnail",
         "url": "/User/31091/CHARLES+MICHAELS",
         "canEdit": false
-      },
-      "body_trunc": "Still have this and use it!"
+      }
     },
     {
       "reviewid": 1343,
@@ -801,8 +780,7 @@
         "avatar": "https://www.cominor.com/static/images/avatars/User/ifixit/avatar-10.thumbnail",
         "url": "/User/2517582/Vera++Steiner",
         "canEdit": false
-      },
-      "body_trunc": "All good, thanks a lot."
+      }
     },
     {
       "reviewid": 1272,
@@ -836,8 +814,7 @@
         "avatar": "https://www.cominor.com/static/images/avatars/User/ifixit/avatar-7.thumbnail",
         "url": "/User/2989515/Felix+von+Hundelshausen",
         "canEdit": false
-      },
-      "body_trunc": "hat seinen Dienst erfüllt"
+      }
     },
     {
       "reviewid": 852,
@@ -956,8 +933,7 @@
         "avatar": "https://www.cominor.com/static/images/avatars/User/ifixit/avatar-6.thumbnail",
         "url": "/User/2902925/Andy+Duran",
         "canEdit": false
-      },
-      "body_trunc": "Excellent product that helped me get the job done!"
+      }
     },
     {
       "reviewid": 617,
@@ -1042,8 +1018,7 @@
         "avatar": "https://www.cominor.com/static/images/avatars/User/ifixit/avatar-10.thumbnail",
         "url": "/User/2854070/Anthony+Finch",
         "canEdit": false
-      },
-      "body_trunc": "I love these things! They are useful for almost any repair job, from tablets, to phones, to laptops, and desktops, they are the swiss army knife of repair tools. The ones from iFixit are much better than the other ones I have used. They last longer,  and they are tougher to break."
+      }
     },
     {
       "reviewid": 445,

--- a/src/lib/product_reviews/review/index.js
+++ b/src/lib/product_reviews/review/index.js
@@ -19,12 +19,13 @@ const Container = styled.div`
 `;
 
 const Review = ({ review, showBorder, locale, reviewsUrl }) => {
-   const { rating, headline, body, body_trunc, author, created_date, productName, productVariantName } = review;
+   const { rating, headline, body, author, created_date, productName, productVariantName } = review;
    const date = new Date(created_date * 1000).toLocaleDateString(locale, {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
    });
+   const body_trunc = body.substring(0, 300);
 
    return (
       <Container


### PR DESCRIPTION
We want to stop passing the truncated body through the api. It is
unnecessary because we can just truncate on the frontend.

This will have to be merged before the ifixit side pull gets merged.

QA:
--
Mess around with the data inside of `src/example/example_reviews.json`. 
You can run `npm start` to bring up the example page and make sure things 
behave properly.

CC @batbattur @ardelato 

Connects https://github.com/iFixit/ifixit/issues/31382