### PR TITLE
Shopify add jsonld review data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12982,6 +12982,22 @@
       "integrity": "sha512-Yzpno3enVzSrSCnnljmr4b/2KUQSMZaPuqmS26t9k4nW7uwJk6STWmH9heNjPuvqUTO3jOSPkHoKgO4+Dw7uIw==",
       "dev": true
     },
+    "react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
+    "react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      }
+    },
     "react-html-attributes": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/react-html-attributes/-/react-html-attributes-1.4.6.tgz",
@@ -14439,6 +14455,11 @@
           "dev": true
         }
       }
+    },
+    "react-side-effect": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
+      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ=="
     },
     "react-star-ratings": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@ifixit/localize": "^1.0.0",
     "@ifixit/toolbox": "^1.1.0",
     "jest-styled-components": "^6.3.3",
+    "react-helmet": "^6.1.0",
     "react-test-renderer": "^16.13.0"
   },
   "scripts": {

--- a/src/lib/product_reviews/__snapshots__/product_reviews.test.js.snap
+++ b/src/lib/product_reviews/__snapshots__/product_reviews.test.js.snap
@@ -174,25 +174,13 @@ exports[`renders correctly 1`] = `
 >
   <div
     className="c1"
-    itemProp="aggregateRating"
-    itemScope={true}
-    itemType="http://schema.org/AggregateRating"
   >
-    <meta
-      content="1"
-      itemProp="worstRating"
-    />
-    <meta
-      content="5"
-      itemProp="bestRating"
-    />
     <div
       className="c2"
     >
       <div>
         <span
           className="c3"
-          itemProp="ratingValue"
         >
           0
         </span>
@@ -484,7 +472,6 @@ exports[`renders correctly 1`] = `
       <h3
         className="c6"
         content={0}
-        itemProp="reviewCount"
       >
         0 reviews
       </h3>

--- a/src/lib/product_reviews/review/author.js
+++ b/src/lib/product_reviews/review/author.js
@@ -29,9 +29,7 @@ const Author = ({ author, reviewsUrl }) => {
       <Container>
          <Link href={url}>
             <Avatar src={avatar} size={28} />
-            <div itemProp="author" itemScope="" itemType="https://schema.org/Person">
-               <Name itemprop="name">{name}</Name>
-            </div>
+            <Name>{name}</Name>
          </Link>
          {canEdit && reviewsUrl && (
             <a href={`${reviewsUrl}?userid=${userid}`}>

--- a/src/lib/product_reviews/review/body.js
+++ b/src/lib/product_reviews/review/body.js
@@ -32,7 +32,7 @@ class ReviewBody extends Component {
 
       return (
          <React.Fragment>
-            <Body itemProp="description">
+            <Body>
                {expanded
                   ? body
                   : `${body_trunc}${body_trunc !== body ? '…' : ''}`}

--- a/src/lib/product_reviews/review/header.js
+++ b/src/lib/product_reviews/review/header.js
@@ -34,14 +34,8 @@ const Header = ({ rating, headline, date, productName, productVariantName }) => 
 
    return (
       <React.Fragment>
-         <Headline itemProp="name">
-            <StarsContainer
-               itemProp="reviewRating"
-               itemScope
-               itemType="http://schema.org/Rating">
-               <meta itemProp="worstRating" content="1" />
-               <meta itemProp="ratingValue" content={rating} />
-               <meta itemProp="bestRating" content="5" />
+         <Headline>
+            <StarsContainer>
                <Stars rating={rating} size={23} activeColor={color.blue[4]} />
             </StarsContainer>
             {headline}
@@ -51,7 +45,7 @@ const Header = ({ rating, headline, date, productName, productVariantName }) => 
                {productName} | {productVariantName}
             </ProductVariantName>
          )}
-         <Timestamp itemProp="datePublished">{date}</Timestamp>
+         <Timestamp>{date}</Timestamp>
       </React.Fragment>
    );
 };

--- a/src/lib/product_reviews/review/index.js
+++ b/src/lib/product_reviews/review/index.js
@@ -28,11 +28,7 @@ const Review = ({ review, showBorder, locale, reviewsUrl }) => {
    const body_trunc = body.substring(0, 300);
 
    return (
-      <Container
-         itemProp="review"
-         itemScope
-         itemType="http://schema.org/Review"
-         showBorder={showBorder}>
+      <Container showBorder={showBorder}>
          <Author author={author} reviewsUrl={reviewsUrl} />
          <Header rating={rating} headline={headline} date={date} productName={productName} productVariantName={productVariantName} />
          <ReviewBody body={body} body_trunc={body_trunc} />

--- a/src/lib/product_reviews/visualizer/index.js
+++ b/src/lib/product_reviews/visualizer/index.js
@@ -97,13 +97,7 @@ class Visualizer extends Component {
       }
 
       return (
-         <Container
-            itemProp="aggregateRating"
-            itemScope
-            itemType="http://schema.org/AggregateRating">
-            <meta itemProp="worstRating" content="1" />
-            <meta itemProp="bestRating" content="5" />
-
+         <Container>
             <Helmet>
                {numReviews > 0 &&
                   <script type="application/ld+json">{JSON.stringify(reviewJsonld)}</script>
@@ -111,7 +105,7 @@ class Visualizer extends Component {
             </Helmet>
             <ContainerHeader>
                <div>
-                  <Aggregate itemProp="ratingValue">{average}</Aggregate>
+                  <Aggregate>{average}</Aggregate>
                   <AggregateSub>&#47; 5</AggregateSub>
                </div>
 
@@ -123,7 +117,7 @@ class Visualizer extends Component {
                   />
                </StarsContainer>
 
-               <ReviewCount itemProp="reviewCount" content={numReviews}>
+               <ReviewCount content={numReviews}>
                   {/* Translators: Number of reviews */}
                   {___p(numReviews, '%1 review', '%1 reviews', numReviews)}
                </ReviewCount>

--- a/src/lib/product_reviews/visualizer/index.js
+++ b/src/lib/product_reviews/visualizer/index.js
@@ -5,6 +5,7 @@ import { Stars, constants } from '@ifixit/toolbox';
 import { ___p } from '@ifixit/localize';
 import ReviewBar from './review_bar';
 import ReviewLink from './review_link';
+import { Helmet } from 'react-helmet';
 
 const { color, fontSize, spacing } = constants;
 
@@ -62,6 +63,44 @@ class Visualizer extends Component {
       const { average, groupedReviews } = productReviews;
       const numReviews = productReviews.count;
 
+      const schemaReviews = productReviews.reviews
+         .slice(0,10)
+         .map(r => {
+            return {
+               "@type": "Review",
+               "reviewRating": {
+                  "@type": "Rating",
+                  "ratingValue": `${r.rating}`,
+                  "bestRating": "5"
+               },
+               "author": {
+                  "@type": "Person",
+                  "name": `${r.author.name}`
+               },
+               "product": {
+                  "@type": "Product",
+                  "name": `${r.productName}`
+               }};
+       });
+
+      const reviewJsonld = {
+         "@context": "http://schema.org/",
+         "@type": "Product",
+         // eslint-disable-next-line no-restricted-globals
+         "url": `${location.href}`,
+         "aggregateRating": {
+           "@type": "AggregateRating",
+           "ratingValue": `${average}`,
+           "reviewCount": `${numReviews}`
+         },
+         "review": [schemaReviews],
+      };
+
+      if (numReviews) {
+         // This is the only way to get the product name with current data provided
+         reviewJsonld["name"] = `${productReviews.reviews[0].productName}`;
+      }
+
       return (
          <Container
             itemProp="aggregateRating"
@@ -70,6 +109,11 @@ class Visualizer extends Component {
             <meta itemProp="worstRating" content="1" />
             <meta itemProp="bestRating" content="5" />
 
+            <Helmet>
+               {numReviews > 0 &&
+                  <script type="application/ld+json">{JSON.stringify(reviewJsonld)}</script>
+               }
+            </Helmet>
             <ContainerHeader>
                <div>
                   <Aggregate itemProp="ratingValue">{average}</Aggregate>

--- a/src/lib/product_reviews/visualizer/index.js
+++ b/src/lib/product_reviews/visualizer/index.js
@@ -68,6 +68,7 @@ class Visualizer extends Component {
          .map(r => {
             return {
                "@type": "Review",
+               "datePublished": r.date,
                "reviewRating": {
                   "@type": "Rating",
                   "ratingValue": r.rating,

--- a/src/lib/product_reviews/visualizer/index.js
+++ b/src/lib/product_reviews/visualizer/index.js
@@ -76,10 +76,6 @@ class Visualizer extends Component {
                "author": {
                   "@type": "Person",
                   "name": r.author.name
-               },
-               "product": {
-                  "@type": "Product",
-                  "name": r.productName
                }};
        });
 

--- a/src/lib/product_reviews/visualizer/index.js
+++ b/src/lib/product_reviews/visualizer/index.js
@@ -70,35 +70,34 @@ class Visualizer extends Component {
                "@type": "Review",
                "reviewRating": {
                   "@type": "Rating",
-                  "ratingValue": `${r.rating}`,
+                  "ratingValue": r.rating,
                   "bestRating": "5"
                },
                "author": {
                   "@type": "Person",
-                  "name": `${r.author.name}`
+                  "name": r.author.name
                },
                "product": {
                   "@type": "Product",
-                  "name": `${r.productName}`
+                  "name": r.productName
                }};
        });
 
       const reviewJsonld = {
          "@context": "http://schema.org/",
          "@type": "Product",
-         // eslint-disable-next-line no-restricted-globals
-         "url": `${location.href}`,
+         "url": window.location.href,
          "aggregateRating": {
            "@type": "AggregateRating",
-           "ratingValue": `${average}`,
-           "reviewCount": `${numReviews}`
+           "ratingValue": average,
+           "reviewCount": numReviews
          },
          "review": [schemaReviews],
       };
 
       if (numReviews) {
          // This is the only way to get the product name with current data provided
-         reviewJsonld["name"] = `${productReviews.reviews[0].productName}`;
+         reviewJsonld["name"] = productReviews.reviews[0].productName;
       }
 
       return (


### PR DESCRIPTION
### Description

This allows google to see our review data better. We had to install
react helmet to be able to update the head from clientside.
Hopefully this resolves our search console issues.

We had to incorporate a workaround to get the product name as of now
as the data isn't easily provided

Open to input on this as I'm not sure what data is exactly desired here, or what the best way to test this is

### QA

Startup the example page and go to the head and verify that you can see the ld+json in the head
If you can see if google recognizes/approves of the data

CC @sterlinghirsh @zdmitchell 
Closes https://github.com/iFixit/ifixit/issues/35369